### PR TITLE
Compatibility with dev tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,10 @@ URL: https://github.com/r-lib/rematch2#readme
 BugReports: https://github.com/r-lib/rematch2/issues
 RoxygenNote: 6.0.1
 Imports:
-    tibble
+    tibble (>= 2.99)
 Suggests:
     covr,
     testthat
+Remotes: 
+    tidyverse/tibble
 Encoding: UTF-8

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -40,7 +40,7 @@ test_that("capture groups", {
   expect_equal(
     as.data.frame(res),
     asdf(
-      list(c("123", "456"), character(), character(), "1", "123"),
+      ...1 = list(c("123", "456"), character(), character(), "1", "123"),
       .text = .text,
       .match = list(c("123", "456"), character(), character(), "1", "123")
     )
@@ -54,7 +54,7 @@ test_that("scalar text with capure groups", {
   res <- re_match_all(.text <- "foo bar", "\\b(\\w+)\\b")
   expect_equal(
     res,
-    df(list(c("foo", "bar")), .text = .text, .match = list(c("foo", "bar")))
+    df(...1 = list(c("foo", "bar")), .text = .text, .match = list(c("foo", "bar")))
   )
 
   res <- re_match_all(.text <- "foo bar", "\\b(?<word>\\w+)\\b")

--- a/tests/testthat/test-exec-all.R
+++ b/tests/testthat/test-exec-all.R
@@ -71,7 +71,7 @@ test_that("capture groups", {
   expect_equal(
     as.data.frame(res),
     asdf(
-      allreclist(
+      ...1 = allreclist(
         mrec(c("123", "456"), c(1L, 8L), c(3L, 10L)), norec(), norec(),
         mrec("1", 1L, 1L), mrec("123", 1, 3)
       ),
@@ -92,7 +92,7 @@ test_that("scalar text with capure groups", {
   expect_equal(
     as.data.frame(res),
     asdf(
-      allreclist(mrec(c("foo", "bar"), c(1L, 5L), c(3L, 7L))),
+      ...1 = allreclist(mrec(c("foo", "bar"), c(1L, 5L), c(3L, 7L))),
       .text = .text,
       .match = allreclist(mrec(c("foo", "bar"), c(1L, 5L), c(3L, 7L)))
     )


### PR DESCRIPTION
Requires tidyverse/tibble@98cac0d.

Do we want to assign names instead of using the automatic `...1` name?