### PR TITLE
Compatibility with tibble 2.1.3 and 3.0.0

### DIFF
--- a/R/exec-all.R
+++ b/R/exec-all.R
@@ -41,7 +41,9 @@ re_exec_all <- function(text, pattern, perl = TRUE, ...) {
   if (length(text) == 0) {
     res <- empty_result(text, pattern, perl = perl, ...)
     for (i in seq_along(res)) {
-      if (is.list(res[[i]])) class(res[[i]]) <- "rematch_allrecords"
+      if (is.list(res[[i]])) {
+        res[[i]] <- new_rematch_allrecords(res[[i]])
+      }
     }
     return(res)
   }
@@ -69,7 +71,7 @@ re_exec_all <- function(text, pattern, perl = TRUE, ...) {
   }
 
   res <- lapply(seq_along(res[[1]]), function(i) {
-    structure(lapply(res, "[[", i), class = "rematch_allrecords")
+    new_rematch_allrecords(lapply(res, "[[", i))
   })
 
   res <- structure(

--- a/R/exec-all.R
+++ b/R/exec-all.R
@@ -121,3 +121,7 @@ exec1 <- function(text1, match1) {
 
   res
 }
+
+new_rematch_allrecords <- function(x) {
+  structure(x, class = c("rematch_allrecords", "list"))
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -34,5 +34,9 @@ reclist <- function(...) {
 }
 
 allreclist <- function(...) {
-  structure(list(...), class = "rematch_allrecords")
+  new_rematch_allrecords(list(...))
+}
+
+new_rematch_allrecords <- function(x) {
+  structure(x, class = c("rematch_allrecords", "list"))
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -36,7 +36,3 @@ reclist <- function(...) {
 allreclist <- function(...) {
   new_rematch_allrecords(list(...))
 }
-
-new_rematch_allrecords <- function(x) {
-  structure(x, class = c("rematch_allrecords", "list"))
-}


### PR DESCRIPTION
Adding an explicit `"list"` class to `"rematch_allrecords"`.